### PR TITLE
feat: 로컬 캐시, 캐시 저장소 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/cache/CacheExampleApplication.java
+++ b/src/main/java/com/example/cache/CacheExampleApplication.java
@@ -1,6 +1,185 @@
 package com.example.cache;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class CacheExampleApplication {
+    private static final KeyStore KEY_STORE = new KeyStore();
+    private static final MCache M_CACHE = new MCache();
+
+    private static final Repository DB = new Repository();
+    private static final CacheStore CACHE_STORE = new CacheStore();
+    private static final Cache<Object, Object> CAFFEINE = Caffeine
+            .newBuilder()
+            .maximumSize(1_000)
+            .expireAfterWrite(60, TimeUnit.MINUTES)
+            .build();
+    private static final LocalDBSyncScheduler SCHEDULER = new LocalDBSyncScheduler(DB);
+    private static final int MAX_ITERATION_COUNT = 10_000;
+    private static final int N_THREADS = 100;
+
     public static void main(String[] args) {
+        System.out.println("쓰레드 개수 : " + N_THREADS);
+        printHeapMemory();
+
+        SCHEDULER.sync(CACHE_STORE.getSyncBuffer());
+
+        // loading cache - mCache
+        동시에_10000번_호출(() -> getMCache());
+        flush한_후에_100번_호출(() -> getMCache());
+        expire가_50퍼센트_된_캐시_동시에_10000번_호출(() -> getMCache());
+
+        // loading cache - caffeine
+        동시에_10000번_호출(() -> getCaffeineCache());
+        flush한_후에_100번_호출(() -> getCaffeineCache());
+        expire가_50퍼센트_된_캐시_동시에_10000번_호출(() -> getCaffeineCache());
+
+        // cache store - hashmap
+        특정_key_동시에_100개_감소();
+        특정_key_동시에_101개_감소();
+        동시에_10000개_읽기_100개_감소();
+
+        // cache store - concurrentHashMap
+        CACHE_STORE.toConcurrentHashMap();
+
+        특정_key_동시에_100개_감소();
+        특정_key_동시에_101개_감소();
+        동시에_10000개_읽기_100개_감소();
+    }
+
+    private static void flush한_후에_100번_호출(Runnable task) {
+        flush();
+
+        System.out.println("flush한 후에 100번 호출");
+        test( 100, task);
+        System.out.println();
+    }
+
+    private static void 동시에_10000번_호출(Runnable task) {
+        createCache();
+
+        System.out.println("동시에 10000번 호출");
+        test( MAX_ITERATION_COUNT, task);
+        System.out.println();
+    }
+
+    private static void expire가_50퍼센트_된_캐시_동시에_10000번_호출(Runnable task) {
+        createCache();
+
+        for (int i = 1; i <= 500; i++) {
+            String key = KEY_STORE.randomKeyByPercentage();
+            M_CACHE.expire(key);
+            CAFFEINE.invalidate(key);
+        }
+
+        System.out.println("expire가 50퍼센트 된 캐시를 동시에 10000번 호출");
+        test( MAX_ITERATION_COUNT, task);
+        System.out.println();
+    }
+
+    private static void 특정_key_동시에_100개_감소() {
+        createCache();
+
+        final String key = "1";
+        System.out.println("특정 key를 동시에 100개 감소");
+        System.out.println("초기 값 : " + CACHE_STORE.read(key));
+
+        test( 100, () -> CACHE_STORE.write(key, -1));
+        System.out.println("감소 후 값 : " + CACHE_STORE.read(key));
+        System.out.println();
+    }
+
+    private static void 특정_key_동시에_101개_감소() {
+        createCache();
+
+        final String key = "1";
+        System.out.println("특정 key를 동시에 101개 감소");
+        System.out.println("초기 값 : " + CACHE_STORE.read(key));
+
+        test( 101, () -> CACHE_STORE.write(key, -1));
+        System.out.println("감소 후 값 : " + CACHE_STORE.read(key));
+        System.out.println();
+    }
+
+    private static void 동시에_10000개_읽기_100개_감소() {
+        createCache();
+
+        System.out.println("동시에 10000개 읽기와 100개 감소");
+        System.out.println("초기 값 : " + CACHE_STORE.getTotalWriteCount());
+
+        AtomicInteger atomicInteger1 = new AtomicInteger(0);
+        test(MAX_ITERATION_COUNT, () -> readAndWrite(atomicInteger1));
+        System.out.println("감소 후 값 : " + CACHE_STORE.getTotalWriteCount());
+        System.out.println();
+    }
+
+    private static void createCache() {
+        for (int i = 1; i <= 1000; i++) {
+            String key = i + "";
+            M_CACHE.put(key, key);
+            CAFFEINE.put(key, key);
+            CACHE_STORE.put(key, 100);
+        }
+    }
+    private static void getMCache() {
+        M_CACHE.get(KEY_STORE.randomKeyByPercentage());
+    }
+
+    private static void getCaffeineCache() {
+        CAFFEINE.get(KEY_STORE.randomKeyByPercentage(),
+                key -> DB.find(key.toString()));
+    }
+
+    private static void flush() {
+        M_CACHE.flush();
+        CAFFEINE.invalidateAll();
+    }
+
+    private static void readAndWrite(AtomicInteger count) {
+        int index = new Random().nextInt(MAX_ITERATION_COUNT);
+
+        if (index <= 130 && count.getAndIncrement() < 100) {
+            CACHE_STORE.write(KEY_STORE.randomKeyByPercentage(), -1);
+        }
+        CACHE_STORE.read(KEY_STORE.randomKeyByPercentage());
+    }
+
+    private static void test(int iterationCount, Runnable task) {
+        long startTime = System.currentTimeMillis();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(N_THREADS);
+        for (int i = 0; i < iterationCount; i++) {
+            executorService.submit(task);
+        }
+
+        executorService.shutdown();
+
+        try {
+            executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+        } catch (InterruptedException e) {
+            System.err.println("쓰레드 풀 종료 중 예외가 발생했습니다: " + e.getMessage());
+        }
+
+        long endTime = System.currentTimeMillis();
+        System.out.println("실행시간: " + (endTime - startTime) + "ms");
+
+        printHeapMemory();
+    }
+
+    private static void printHeapMemory() {
+        long heapSize = Runtime.getRuntime().totalMemory();
+        long heapMaxSize = Runtime.getRuntime().maxMemory();
+        long heapFreeSize = Runtime.getRuntime().freeMemory();
+
+        System.out.println("현재 힙 메모리 사이즈: " + heapSize / (1024 * 1024) + "MB");
+        System.out.println("최대 힙 메모리 사이즈: " + heapMaxSize / (1024 * 1024) + "MB");
+        System.out.println("free 메모리 사이즈: " + heapFreeSize / (1024 * 1024) + "MB");
+        System.out.println();
     }
 }

--- a/src/main/java/com/example/cache/CacheStore.java
+++ b/src/main/java/com/example/cache/CacheStore.java
@@ -1,0 +1,47 @@
+package com.example.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CacheStore {
+    private Map<String, AtomicInteger> cache = new HashMap<>();
+    private final Map<String, AtomicInteger> syncBuffer = new ConcurrentHashMap<>();
+
+    public void toConcurrentHashMap() {
+        cache = new ConcurrentHashMap<>();
+    }
+
+    public Integer read(String key) {
+        return cache.get(key).intValue();
+    }
+
+    public void write(String key, int value) {
+        AtomicInteger cacheValue = cache.get(key);
+
+        if (cacheValue.addAndGet(value) < 0) {
+            cacheValue.set(0);
+        }
+
+        syncBuffer.putIfAbsent(key, cacheValue);
+    }
+
+    public void put(String key, int value) {
+        cache.put(key, new AtomicInteger(value));
+    }
+
+    public int getTotalWriteCount() {
+        int remainSum = 0;
+        for (AtomicInteger value : cache.values()) {
+            remainSum += value.get();
+        }
+
+        int initialSum = 100 * cache.size();
+        return initialSum - remainSum;
+    }
+
+    public Map<String, AtomicInteger> getSyncBuffer() {
+        return syncBuffer;
+    }
+}

--- a/src/main/java/com/example/cache/CacheValue.java
+++ b/src/main/java/com/example/cache/CacheValue.java
@@ -1,0 +1,14 @@
+package com.example.cache;
+
+public class CacheValue {
+    String value;
+    boolean expired;
+
+    public CacheValue(String value) {
+        this.value = value;
+    }
+
+    public void expire() {
+        expired = true;
+    }
+}

--- a/src/main/java/com/example/cache/KeyStore.java
+++ b/src/main/java/com/example/cache/KeyStore.java
@@ -1,0 +1,33 @@
+package com.example.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class KeyStore {
+    private final List<String> frequentlyAccessedKeys = new ArrayList<>();
+    private final List<String> infrequentlyAccessedKeys = new ArrayList<>();
+    private final Random random = new Random();
+
+    public KeyStore() {
+        for (int i = 1; i <= 200; i++) {
+            frequentlyAccessedKeys.add(i + "");
+        }
+
+        for (int i = 201; i <= 1000; i++) {
+            infrequentlyAccessedKeys.add(i + "");
+        }
+    }
+
+    public String randomKeyByPercentage() {
+        double randomValue = random.nextDouble();
+
+        if (randomValue < 0.2) {
+            int index = random.nextInt(infrequentlyAccessedKeys.size());
+            return infrequentlyAccessedKeys.get(index);
+        } else {
+            int index = random.nextInt(frequentlyAccessedKeys.size());
+            return frequentlyAccessedKeys.get(index);
+        }
+    }
+}

--- a/src/main/java/com/example/cache/LocalDBSyncScheduler.java
+++ b/src/main/java/com/example/cache/LocalDBSyncScheduler.java
@@ -1,0 +1,26 @@
+package com.example.cache;
+
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LocalDBSyncScheduler {
+    private final Repository repository;
+
+    public LocalDBSyncScheduler(Repository repository) {
+        this.repository = repository;
+    }
+
+    public void sync(Map<String, AtomicInteger> syncBuffer) {
+        Timer timer = new Timer();
+        long interval = 10 * 1000;
+
+        timer.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                repository.bulkUpdate(syncBuffer);
+            }
+        }, 0, interval);
+    }
+}

--- a/src/main/java/com/example/cache/MCache.java
+++ b/src/main/java/com/example/cache/MCache.java
@@ -1,0 +1,51 @@
+package com.example.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MCache {
+    private final Map<String, CacheValue> cache = new ConcurrentHashMap<>();
+    private final Map<String, AtomicInteger> counter = new ConcurrentHashMap<>();
+    private final Repository db = new Repository();
+
+    public String get(String key) {
+        System.out.println(key);
+        CacheValue cacheValue = cache.computeIfAbsent(key, k -> init(key));
+        if (!cacheValue.expired) {
+            return cacheValue.value;
+        }
+
+        AtomicInteger first = counter.get(key);
+
+        if (first.getAndIncrement() == 1) {
+            String dbValue = db.find(key);
+            this.put(key, dbValue);
+            return dbValue;
+        } else {
+            return cacheValue.value;
+        }
+    }
+    private CacheValue init(String key) {
+        String dbValue = db.find(key);
+        counter.put(key, new AtomicInteger(0));
+        return new CacheValue(dbValue);
+    }
+
+    public void put(String key, String value) {
+        cache.put(key, new CacheValue(value));
+        counter.put(key, new AtomicInteger(0));
+    }
+
+    public void expire(String key) {
+        CacheValue cacheValue = cache.get(key);
+
+        if (cacheValue != null) {
+            cacheValue.expire();
+        }
+    }
+
+    public void flush() {
+        cache.clear();
+    }
+}

--- a/src/main/java/com/example/cache/MCache.java
+++ b/src/main/java/com/example/cache/MCache.java
@@ -10,7 +10,6 @@ public class MCache {
     private final Repository db = new Repository();
 
     public String get(String key) {
-        System.out.println(key);
         CacheValue cacheValue = cache.computeIfAbsent(key, k -> init(key));
         if (!cacheValue.expired) {
             return cacheValue.value;

--- a/src/main/java/com/example/cache/MCache.java
+++ b/src/main/java/com/example/cache/MCache.java
@@ -17,7 +17,7 @@ public class MCache {
 
         AtomicInteger first = counter.get(key);
 
-        if (first.getAndIncrement() == 1) {
+        if (first.getAndIncrement() == 0) {
             String dbValue = db.find(key);
             this.put(key, dbValue);
             return dbValue;

--- a/src/main/java/com/example/cache/Repository.java
+++ b/src/main/java/com/example/cache/Repository.java
@@ -1,0 +1,36 @@
+package com.example.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Repository {
+    private int postFix;
+    private final Map<String, Integer> db = new HashMap<>();
+
+    public String find(String key) {
+        try {
+            Thread.sleep(100L);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return key + postFix++;
+    }
+
+    public void bulkUpdate(Map<String, AtomicInteger> origin) {
+        Map<String, AtomicInteger> copy = new HashMap<>(origin);
+        Map<String, Integer> updatedData = new HashMap<>();
+
+        copy.forEach((key, value) -> {
+            origin.remove(key, value);
+            updatedData.put(key, value.get());
+        });
+
+        try {
+            Thread.sleep(100L);
+            db.putAll(updatedData);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
로딩 캐시의 만료된 캐시에 접근할 때는 AtomicIntger를 이용해서 최초 접근할 때만 db조회하고 나머지는 현재 값을 그대로 반환하도록 구현했습니다.

캐시 저장소 같은 경우에는 명시적으로 lock을 사용하기 보다 AtomicInteger로 lock의 특성을 살리는 방향으로 구현했습니다.
db 동기화 하는 부분은 매번 싱크를 맞춰주지 않고 스케줄러를 통해 bulkUpdate하는 방향으로 구현했습니다.

로딩 캐시와 캐시 저장소는 각각 따로 구현하고  
추후에 기능이 추가되거나 변경되면서 기능이 좀 정제된 후에 리팩토링 진행하려고
아직은 인터페이스 통일을 하지 않았습니다.

성능 비교는 쓰레드 10개에서 수행 시간과 메모리 스냅샷을 측정했습니다.

초기 값
힙 메모리 사이즈: 256MB
최대. 힙 메모리 사이즈: 4096MB
free메모리 사이즈: 251MB

동시에 10000번 호출 - mCache
실행시간: 244ms
free 메모리 사이즈: 235MB

flush한 후에 100번 호출 - mCache
실행시간: 1276ms
free 메모리 사이즈: 233MB

expire가 50퍼센트 된 캐시를 동시에 10000번 호출 - mCache
실행시간: 1631ms
free 메모리 사이즈: 230MB

동시에 10000번 호출 - caffeine
실행시간: 259ms
free 메모리 사이즈: 234MB

flush한 후에 100번 호출 - caffeine
실행시간: 1801ms
free 메모리 사이즈: 229MB

expire가 50퍼센트 된 캐시를 동시에 10000번 호출 - caffeine
실행시간: 1677ms
free 메모리 사이즈: 155MB

특정 key를 동시에 100개 감소 - hash map
실행시간: 42ms
free 메모리 사이즈: 237MB
초기 값 : 100
감소 후 값 : 0

특정 key를 동시에 101개 감소 - hash map
실행시간: 46ms
free 메모리 사이즈: 237MB
초기 값 : 100
감소 후 값 : 0

동시에 10000개 읽기와 100개 감소 - hash map
실행시간: 239ms
free 메모리 사이즈: 234MB
초기 값 : 0
감소 후 값 : 100

특정 key를 동시에 100개 감소 - Concurrent hash map
실행시간: 60ms
free 메모리 사이즈: 237MB
초기 값 : 100
감소 후 값 : 0

특정 key를 동시에 101개 감소 - Concurrent hash map
실행시간: 72ms
free 메모리 사이즈: 248MB
초기 값 : 100
감소 후 값 : 0

동시에 10000개 읽기와 100개 감소 - Concurrent hash map
실행시간: 341ms
free 메모리 사이즈: 235MB
초기 값 : 0
감소 후 값 : 100

현재 main() 메소드에서는 모든 요구사항을 한번에 실행하게끔 되어 있는데 성능 비교를 할 때는 주석처리를 하여
한번에 하나의 기능만 테스트하였습니다.

로딩 캐시에서는 caffeine캐시와 성능 차이가 크게 나지 않았는데.. 정확하게 측정된건지는 잘 모르겠네요 ㅜ..

캐시 저장소 같은 경우에는 성능 차이는 크게 없지만 hashMap이 근소하게 빨랐습니다.

과제 진행하면서 CAS(compare and swap), CompletableFuture, ReentrantRock에 대한 
개념도 조금씩 공부하면서 진행을 했는데 로딩 캐시, 캐시 저장소에서 잘못된 접근이나 더 좋은 접근이 있으면 코멘트 부탁드립니다~!